### PR TITLE
Add FlutterScript Client/Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ that class.
 
 ```
 
+## FlutterScript server
+
+You can embed a flutter script interpreter into an application and
+have it listen for requests on a port. Posting to this server will
+result execute the code and write the output to the response.
+
+``` dart
+import "package:flutterscript/server.dart"
+
+Future startServer(int port) async {
+  Server server = await Server.create(port);
+  return server.listen();
+}
+
+```
+
+The `Future` returned by `startServer` will complete when the server
+is shutdown or crashes.
+
 ## Development
 
 

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -1,0 +1,32 @@
+import "dart:io";
+import "dart:async";
+import "dart:convert";
+
+main(List<String> args) async {
+  var client = Client(Uri.parse(args.first));
+
+  var lines = stdin.transform(Utf8Decoder()).transform(LineSplitter());
+
+  stdout.write("> ");
+  await for (String line in lines) {
+    var response = await client.eval(line);
+    await stdout.addStream(response);
+    stdout.write("\n> ");
+  }
+}
+
+class Client {
+  HttpClient http;
+  Uri uri;
+
+  Client(this.uri) {
+    this.http = HttpClient();
+  }
+
+  Future<Stream<List<int>>> eval(String line) async {
+    var request = await http.openUrl("POST", uri);
+    request.add(Utf8Codec().encode(line));
+    return request.close();
+
+  }
+}

--- a/lib/flutterscript.dart
+++ b/lib/flutterscript.dart
@@ -152,7 +152,10 @@ class FlutterScript {
   }
 
   Future<Object> eval(String source) async {
-    Stream<String> input = Stream.fromFuture(Future(() => source));
+    return evalStream(Stream.fromFuture(Future(() => source)));
+  }
+
+  Future<Object> evalStream(Stream<String> input) async {
     input = input.transform(const LineSplitter());
     var lines = new StreamIterator(input);
     var reader = new Reader(lines);

--- a/lib/server.dart
+++ b/lib/server.dart
@@ -1,0 +1,38 @@
+import "lisp.dart";
+import "dart:io";
+import "dart:async";
+import "dart:convert";
+import "flutterscript.dart";
+
+void main(List<String> args) async {
+  Server server = await Server.create(3001);
+  print("listening on port 3001");
+  await server.listen();
+}
+
+class Server {
+  FlutterScript interpreter;
+  HttpServer http;
+  int port;
+
+  Server(this.interpreter, this.http);
+
+  static Future<Server> create(int port) async {
+    FlutterScript interp = await FlutterScript.create();
+    HttpServer http = await HttpServer.bind(InternetAddress.anyIPv6, port);
+    return Server(interp, http);
+  }
+
+  listen() async {
+    await for (HttpRequest request in http) {
+      Stream<String> body = request.transform(Utf8Decoder());
+      try {
+        var x = await interpreter.evalStream(body);
+        request.response.write(str(x));
+      } catch (error) {
+        request.response.write(error);
+      }
+      request.response.close();
+    }
+  }
+}


### PR DESCRIPTION
A use-case for FlutterScript is to be able to act at a distance on Flutter applications that are running on other machines.

This adds a `Server` that can interpret FlutterScript over Http, as well as a `Client` class that can be used to send requests to the server.

These two classes can be used to create a very simple console based repl.

![2019-06-13 12 14 45](https://user-images.githubusercontent.com/4205/59453316-3fd53a80-8dd5-11e9-8a3a-55247758541c.gif)
